### PR TITLE
Update CloudWatch event rule to use detail-type

### DIFF
--- a/source/cdk/lib/vod-foundation-stack.ts
+++ b/source/cdk/lib/vod-foundation-stack.ts
@@ -297,7 +297,7 @@ export class VodFoundation extends cdk.Stack {
                 enabled: true,
                 eventPattern: {
                     "source": ["aws.mediaconvert"],
-                    "detail": {
+                    "detail-type": {
                         "userMetadata": {
                             "StackName": [
                                 cdk.Aws.STACK_NAME


### PR DESCRIPTION
**Issue**

CloudWatch event is not triggering Lambda function for MediaConvert events. When created manually from AWS Console, the event pattern is expected to be following:

```
{
  "detail-type": [
    "MediaConvert Job State Change"
  ],
  "source": [
    "aws.mediaconvert"
  ]
}
```

**Description of changes:**

By changing the CloudWatch event pattern from `detail` to `detail-type`, MediaConvert events started to trigger Lambda Function.
