### PR TITLE
(feat): Add job to generate poster images

### DIFF
--- a/source/custom-resource/lib/s3/job-settings.json
+++ b/source/custom-resource/lib/s3/job-settings.json
@@ -568,6 +568,35 @@
               "StreamInfResolution": "INCLUDE"
             }
           }
+        },
+        {
+          "Name": "File Group",
+          "OutputGroupSettings": {
+            "Type": "FILE_GROUP_SETTINGS",
+            "FileGroupSettings": {
+              "Destination": "s3://destinationbucket/guid/hls/"
+            }
+          },
+          "Outputs": [
+            {
+              "VideoDescription": {
+                "CodecSettings": {
+                  "Codec": "FRAME_CAPTURE",
+                  "FrameCaptureSettings": {
+                    "Quality": 80,
+                    "FramerateNumerator": 30,
+                    "FramerateDenominator": 80,
+                    "MaxCaptures": 1
+                  }
+                }
+              },
+              "ContainerSettings": {
+                "Container": "RAW"
+              },
+              "Extension": "jpg"
+            }
+          ],
+          "CustomName": "Poster Images"
         }
       ],
       "AdAvailOffset": 0,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds an output group for generating a poster image from the uploaded video.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
